### PR TITLE
Overrides the default registrations controller provided by devise.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,5 @@ gem 'compass-rails', '~> 1.1.7'
 group :test, :development do
   gem 'rspec'
   gem 'rspec-rails'
+  gem 'byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,10 @@ GEM
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.2)
+    byebug (3.5.1)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+      slop (~> 3.6)
     chunky_png (1.3.2)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -40,6 +44,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    columnize (0.8.9)
     compass (0.12.7)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -47,6 +52,7 @@ GEM
     compass-rails (1.1.7)
       compass (>= 0.12.2)
       sprockets (<= 2.11.0)
+    debugger-linecache (1.2.0)
     devise (3.2.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -124,6 +130,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    slop (3.6.0)
     spring (1.1.3)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -156,6 +163,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass
+  byebug
   coffee-rails (~> 4.0.0)
   compass-rails (~> 1.1.7)
   devise

--- a/app/assets/javascripts/registrations.js.coffee
+++ b/app/assets/javascripts/registrations.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/registrations.css.scss
+++ b/app/assets/stylesheets/registrations.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the registrations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    fields = [:first_name, :last_name, :email, :password, :password_confirmation,
+    fields = [:first_name, :last_name, :email, :password, :password_confirmation, :current_password, 
       :remember_me, :company, :phone, :fax, :address1, :address2, :city, :state, :zipcode]
 
     devise_parameter_sanitizer.for(:sign_in) { |u| u.permit(:email, :password, :remember_me) }

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,39 @@
+class RegistrationsController < Devise::RegistrationsController
+  def update
+    account_update_params = devise_parameter_sanitizer.sanitize(:account_update)
+
+    # required for settings form to submit when password is left blank
+    if account_update_params[:password].blank?
+      account_update_params.delete("password")
+      account_update_params.delete("password_confirmation")
+    end
+
+    @user = User.find(current_user.id)
+
+    successfully_updated = if needs_password?(@user, params)
+      @user.update_with_password(account_update_params)
+    else
+      # remove the virtual current_password attribute update_without_password
+      # doesn't know how to ignore it
+      account_update_params.delete("current_password")
+      @user.update_without_password(account_update_params)
+    end
+  
+    if successfully_updated
+      set_flash_message :notice, :updated
+      # Sign in the user bypassing validation in case his password changed
+      sign_in @user, bypass: true
+      redirect_to after_update_path_for(@user)
+    else
+      render "edit"
+    end
+  end
+
+  private
+
+  # check if we need password to update user data
+  # ie if password or email was changed, extend this as needed
+  def needs_password?(user, params)
+    user.email != params[:user][:email] || params[:user][:password].present?
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,39 +1,11 @@
 class RegistrationsController < Devise::RegistrationsController
-  def update
-    account_update_params = devise_parameter_sanitizer.sanitize(:account_update)
 
-    # required for settings form to submit when password is left blank
-    if account_update_params[:password].blank?
-      account_update_params.delete("password")
-      account_update_params.delete("password_confirmation")
-    end
-
-    @user = User.find(current_user.id)
-
-    successfully_updated = if needs_password?(@user, params)
-      @user.update_with_password(account_update_params)
+  def update_resource(resource, params)
+    if resource.password != params[:password] ||
+      resource.email != params[:email] 
+      resource.update_with_password(params)
     else
-      # remove the virtual current_password attribute update_without_password
-      # doesn't know how to ignore it
-      account_update_params.delete("current_password")
-      @user.update_without_password(account_update_params)
+      resource.update_without_password(params)
     end
-  
-    if successfully_updated
-      set_flash_message :notice, :updated
-      # Sign in the user bypassing validation in case his password changed
-      sign_in @user, bypass: true
-      redirect_to after_update_path_for(@user)
-    else
-      render "edit"
-    end
-  end
-
-  private
-
-  # check if we need password to update user data
-  # ie if password or email was changed, extend this as needed
-  def needs_password?(user, params)
-    user.email != params[:user][:email] || params[:user][:password].present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  validates_presence_of :password_confirmation, message: "must be same as password"
   validates_presence_of :first_name, message: "can't be blank"
   validates_presence_of :last_name, message: "can't be blank"
   validates_presence_of :phone, message: "can't be blank"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "registrations" }
   get 'styleguide/index'
 
   get 'styleguide' => 'styleguide#index'

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RegistrationsController, :type => :controller do
+
+end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
-RSpec.describe RegistrationsController, :type => :controller do
+describe RegistrationsController do
+  describe "#update_resource" do
+    let(:user) { object_double(User.new, password: "password", email: "email@email.com", update_with_password: true, update_without_password: true) }
 
+    it "calls user.update_with_password when user changes password" do
+      expect(user).to receive(:update_with_password)
+      controller.update_resource(user, { password: "pa55w0rd", first_name: "User" })
+    end
+
+    it "calls user.update_with_password when user changes email" do
+      expect(user).to receive(:update_with_password)
+      controller.update_resource(user, { email: "test@test.com", first_name: "User" })
+    end
+
+    it "calls user.update_without_password when user does not change password or email" do
+      expect(user).to receive(:update_without_password)
+      controller.update_resource(user, { password: user.password, email: user.email, first_name: "User" })
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,12 +19,6 @@ describe User do
     expect(user).to_not be_valid
   end
 
-  it "is not valid without password confirmation" do
-    user = User.new(email: "email@test.com", password: "password", first_name: "Test",
-      last_name: "User", phone: "1234567890")
-    expect(user).to_not be_valid
-  end
-
   it "password and password confirmation must be the same" do
     user = User.new(email: "email@test.com", password: "password", password_confirmation: "wordpass",
       first_name: "Test", last_name: "User", phone: "1234567890")


### PR DESCRIPTION
Edit profile now only requires password when trying to change email or password.
Password confirmation was not needed as devise provides this.
Fixes #20 
